### PR TITLE
Added support for dropping external events onto the calendar with multiple columns

### DIFF
--- a/fullcalendar-columns.js
+++ b/fullcalendar-columns.js
@@ -186,6 +186,9 @@
 			fakeEvent.start = location.start.clone();
 			fakeEvent.end = location.end.clone();
 			var event = this.originalEvents[fakeEvent._id];
+			if (event == null) {
+				return
+			}
 			location = this._computeOriginalEvent(location);
 			return AgendaView.prototype[rescheduleType].call(
 				this, event, location, largeUnit, el, ev

--- a/fullcalendar-columns.js
+++ b/fullcalendar-columns.js
@@ -51,6 +51,19 @@
 				'reportEventDrop', event, location, largeUnit, el, ev
 			);
 		},
+		reportExternalDrop: function(meta, dropLocation, el, ev, ui) {
+			var eventProps = meta.eventProps;
+			var eventInput;
+			var event;
+
+			dropLocation = this._computeOriginalEvent(dropLocation);
+			if (eventProps) {
+				eventInput = $.extend({}, eventProps, dropLocation);
+				event = this.calendar.renderEvent(eventInput, meta.stick)[0]; // renderEvent returns an array
+			}
+	
+			this._triggerExternalDrop(event, dropLocation, el, ev, ui);
+		},
 		updateEvent: function(event) {
 			$.extend(
 				this._getFakeEvent(event._id), this._computeFakeEvent(event)
@@ -177,6 +190,15 @@
 			return AgendaView.prototype[rescheduleType].call(
 				this, event, location, largeUnit, el, ev
 			);
+		},
+		// Triggers external-drop handlers that have subscribed via the API
+		_triggerExternalDrop: function(event, dropLocation, el, ev, ui) {
+			// trigger 'drop' regardless of whether element represents an event
+			this.trigger('drop', el[0], dropLocation.start, ev, ui);
+	
+			if (event) {
+				this.trigger('eventReceive', null, event); // signal an external event landed
+			}
 		}
 	});
 	var origFullCalendar = $.fn.fullCalendar;


### PR DESCRIPTION
Hi Michael,

as I needed to be able to drop external events onto the calendar and noted that it is not fully supported with your multi column solution. I tried to fix it myself, by adding a "reportExternalDrop" and "_triggerExternalDrop" function to your fullcalendar-columns.js

As of now, it seems to work for me (with v. 2.40). However, I would appreciate if you could recheck the code I added and make sure I didn't miss anything.

Thanks.

Best regards,

Tom
